### PR TITLE
Updated firewall package and enabling of SYN_COOKIES in 3.2 Kernel

### DIFF
--- a/attitude_adjustment/package/firewall/Makefile
+++ b/attitude_adjustment/package/firewall/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 OpenWrt.org
+# Copyright (C) 2013-2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=firewall
-PKG_VERSION:=2013-06-29
+PKG_VERSION:=2014-09-19
 PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://nbd.name/firewall3.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=635d8b088607ccb7a3124ce43469cda52150f484
+PKG_SOURCE_VERSION:=50e97c52e75bdfd325cf20d43b32d294ff84d92f
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_MAINTAINER:=Jo-Philipp Wich <jow@openwrt.org>
 
@@ -26,7 +26,7 @@ define Package/firewall
   SECTION:=net
   CATEGORY:=Base system
   TITLE:=OpenWrt C Firewall
-  DEPENDS:=+libubox +libubus +libuci +libip4tc +IPV6:libip6tc +libxtables
+  DEPENDS:=+libubox +libubus +libuci +libip4tc +IPV6:libip6tc +libxtables +kmod-ipt-core +kmod-ipt-nat
 endef
 
 define Package/firewall/description

--- a/attitude_adjustment/target/linux/generic/config-3.2
+++ b/attitude_adjustment/target/linux/generic/config-3.2
@@ -704,7 +704,7 @@ CONFIG_IP_PNP_BOOTP=y
 # CONFIG_NET_IPGRE_DEMUX is not set
 # CONFIG_IP_MROUTE is not set
 # CONFIG_ARPD is not set
-# CONFIG_SYN_COOKIES is not set
+CONFIG_SYN_COOKIES=y
 # CONFIG_INET_AH is not set
 # CONFIG_INET_ESP is not set
 # CONFIG_INET_IPCOMP is not set


### PR DESCRIPTION
This contains the updated firewall package necessary to resolve the issues with combining port forwarding and IPv6.. this is a reflection of OpenWRT issue documented here: https://dev.openwrt.org/changeset/42610

This also enables SYN_COOKIES in the 3.2 kernel we're currently using, which will address an error being shown during an "fw3 start/stop/reload" and give us TCP SYN cookies going forward.

EDIT: This should also close issue #28 once it's tested and merged into Master
